### PR TITLE
feat: Mypage에서 로그인한 유저 닉네임 표시 및 작성글 필터링 기능 추가

### DIFF
--- a/front/src/components/ProfileModal.jsx
+++ b/front/src/components/ProfileModal.jsx
@@ -4,15 +4,23 @@ import Button from '../components/Button';
 import InputField from './InputField';
 import exitIcon from '../assets/exit.png';
 
-const ProfileModal = ({ onClose }) => {
+const ProfileModal = ({ onClose, onNicknameChange, onImageChange }) => {
   const [profileImage, setProfileImage] = useState(null);
   const [nickname, setNickname] = useState('');
   const fileInputRef = useRef(null);
 
   // 기존 닉네임을 불러와서 초기값으로 설정
   useEffect(() => {
+    const savedImage = localStorage.getItem('profileImage');
+    if (savedImage) setProfileImage(savedImage);
     const storedNickname = localStorage.getItem('nickname');
     if (storedNickname) setNickname(storedNickname);
+  }, []);
+
+  // 기존 프로필 이미지를 불러와서 초기값으로 설정
+  useEffect(() => {
+    const savedImage = localStorage.getItem('profileImage');
+    if (savedImage) setProfileImage(savedImage);
   }, []);
 
   const handleImageClick = () => {
@@ -22,16 +30,23 @@ const ProfileModal = ({ onClose }) => {
   const handleImageChange = (e) => {
     const file = e.target.files[0];
     if (file) {
-      setProfileImage(URL.createObjectURL(file));
+      const reader = new FileReader();
+      reader.onloadend = () => {
+        const base64 = reader.result;
+        setProfileImage(base64);
+        localStorage.setItem('profileImage', base64);
+        onImageChange(base64);
+      };
+      reader.readAsDataURL(file);
     }
   };
 
   const handleComplete = () => {
     if (nickname.trim()) {
-      localStorage.setItem('nickname', nickname); // 새 닉네임 저장
+      localStorage.setItem('nickname', nickname);
+      onNicknameChange(nickname);
     }
-    onClose(); // 모달 닫기
-    window.location.reload(); // 새로고침해서 반영되도록
+    onClose();
   };
 
   return (
@@ -50,6 +65,7 @@ const ProfileModal = ({ onClose }) => {
             className="avatar"
             onClick={handleImageClick}
           />
+
           <input
             type="file"
             accept="image/*"

--- a/front/src/components/ProfileModal.jsx
+++ b/front/src/components/ProfileModal.jsx
@@ -32,10 +32,10 @@ const ProfileModal = ({ onClose, onNicknameChange, onImageChange }) => {
     if (file) {
       const reader = new FileReader();
       reader.onloadend = () => {
-        const base64 = reader.result;
-        setProfileImage(base64);
-        localStorage.setItem('profileImage', base64);
-        onImageChange(base64);
+        const base64Image = reader.result;
+        setProfileImage(base64Image);
+        localStorage.setItem('profileImage', base64Image);
+        onImageChange(base64Image); // 상태 + fetch 동시 처리
       };
       reader.readAsDataURL(file);
     }
@@ -43,8 +43,7 @@ const ProfileModal = ({ onClose, onNicknameChange, onImageChange }) => {
 
   const handleComplete = () => {
     if (nickname.trim()) {
-      localStorage.setItem('nickname', nickname);
-      onNicknameChange(nickname);
+      onNicknameChange(nickname); // 상태 + fetch 동시 처리
     }
     onClose();
   };

--- a/front/src/components/ProfileModal.jsx
+++ b/front/src/components/ProfileModal.jsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from 'react';
+import React, { useRef, useState, useEffect } from 'react';
 import './ProfileModal.css';
 import Button from '../components/Button';
 import InputField from './InputField';
@@ -6,7 +6,14 @@ import exitIcon from '../assets/exit.png';
 
 const ProfileModal = ({ onClose }) => {
   const [profileImage, setProfileImage] = useState(null);
+  const [nickname, setNickname] = useState('');
   const fileInputRef = useRef(null);
+
+  // 기존 닉네임을 불러와서 초기값으로 설정
+  useEffect(() => {
+    const storedNickname = localStorage.getItem('nickname');
+    if (storedNickname) setNickname(storedNickname);
+  }, []);
 
   const handleImageClick = () => {
     fileInputRef.current.click();
@@ -19,11 +26,19 @@ const ProfileModal = ({ onClose }) => {
     }
   };
 
+  const handleComplete = () => {
+    if (nickname.trim()) {
+      localStorage.setItem('nickname', nickname); // 새 닉네임 저장
+    }
+    onClose(); // 모달 닫기
+    window.location.reload(); // 새로고침해서 반영되도록
+  };
+
   return (
     <div className="modal-backdrop">
       <div className="modal-content">
         <button className="close-btn" onClick={onClose}>
-          <img src={exitIcon} />
+          <img src={exitIcon} alt="닫기 아이콘" />
         </button>
 
         <h3>프로필 수정</h3>
@@ -46,6 +61,8 @@ const ProfileModal = ({ onClose }) => {
           <InputField
             type="text"
             placeholder="닉네임 입력"
+            value={nickname}
+            onChange={(e) => setNickname(e.target.value)}
             className="nickname-input"
           />
         </div>
@@ -53,7 +70,7 @@ const ProfileModal = ({ onClose }) => {
         <Button
           className="small-btn"
           label="완료"
-          onClick={onClose}
+          onClick={handleComplete}
           variant="primary"
         />
       </div>

--- a/front/src/pages/Home.jsx
+++ b/front/src/pages/Home.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect, use } from 'react';
 import Header from '../components/Header';
 import BottomNavBar from '../components/BottomNavBar';
 import '../index.css';
@@ -7,6 +7,7 @@ import FloatingActionButton from '../pages/FloatingActionButton';
 import { useNavigate } from 'react-router-dom';
 
 const Home = () => {
+  const [nickname, setNickname] = useState('');
   const [activeTab, setActiveTab] = useState('home');
 
   const navigate = useNavigate();
@@ -14,9 +15,20 @@ const Home = () => {
     navigate('/write');
   };
 
+  useEffect(() => {
+    const storedNickname = localStorage.getItem('nickname');
+    if (!storedNickname) {
+      alert('로그인이 필요합니다.');
+      window.location.href = '/login';
+      return;
+    }
+    setNickname(storedNickname);
+  }, [navigate]);
+
   return (
     <div className="page-layout">
-      <Header username="독수리" />
+      {/* nickname을 Header에 전달 */}
+      <Header username={nickname} />
 
       <main className="home-content">
         <div>

--- a/front/src/pages/Login.jsx
+++ b/front/src/pages/Login.jsx
@@ -15,39 +15,37 @@ const Login = () => {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [showPassword, setShowPassword] = useState(false);
-/*
-  const handleLogin = () => {
-    console.log('로그인 시도: ', email, password);
-    // TODO: 로그인 로직 추가
+
+  const handleLogin = async () => {
+    try {
+      const response = await fetch('http://localhost:8080/api/user/login', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          email: email,
+          password: password,
+        }),
+      });
+
+      const result = await response.json();
+
+      if (result.success) {
+        console.log('login success', result);
+
+        // 닉네임 로컬스토리지에 저장해서 다른 페이지에서 사용
+        localStorage.setItem('nickname', result.nickname);
+
+        navigate('/home');
+      } else {
+        alert('로그인 실패: ' + result.message);
+      }
+    } catch (error) {
+      console.error('🚨 서버 연결 실패:', error);
+      alert('서버와 연결할 수 없습니다.');
+    }
   };
-*/const handleLogin = async () => {
-        try {
-            const response = await fetch("http://localhost:8080/api/user/login", {
-                method: "POST",
-                headers: {
-                    "Content-Type": "application/json"
-                },
-                body: JSON.stringify({
-                    email: email,
-                    password: password
-                })
-            });
-
-            const result = await response.json();
-
-
-            if(result.success){
-                console.log("login success", result);
-                navigate("/home");
-            }else{
-                alert("로그인 실패: " + result.message);
-            }
-
-        } catch (error) {
-            console.error("🚨 서버 연결 실패:", error);
-            alert("서버와 연결할 수 없습니다.");
-        }
-    };
 
   return (
     <div className="page-layout login-container">

--- a/front/src/pages/MyPage.jsx
+++ b/front/src/pages/MyPage.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import Header from '../components/Header';
 import BottomNavBar from '../components/BottomNavBar';
 import Button from '../components/Button';
@@ -18,19 +18,34 @@ const dummyPosts = [
 ];
 
 const MyPage = () => {
-  const username = '독수리';
+  const [nickname, setNickname] = useState('');
   const [activeTab, setActiveTab] = useState('mypage');
   const [isModalOpen, setIsModalOpen] = useState(false);
 
-  const myPosts = dummyPosts.filter((post) => post.author === username);
+  useEffect(() => {
+    // 로그인한 사용자만 접근 가능하므로, nickname은 항상 존재한다고 가정
+    const storedNickname = localStorage.getItem('nickname');
+
+    // 혹시라도 토큰 없이 들어온 경우 방어용
+    if (!storedNickname) {
+      alert('로그인이 필요합니다.');
+      window.location.href = '/login';
+      return;
+    }
+
+    setNickname(storedNickname);
+  }, []);
+
+  const myPosts = dummyPosts.filter((post) => post.author === nickname);
 
   return (
     <div className="page-layout mypage">
-      <Header username="독수리" />
+      <Header username={nickname} />
+
       <section className="profile">
         <div className="pic-name">
           <img src={profileGray} alt="아바타" className="avatar" />
-          <h2 className="nickname">{username}</h2>
+          <h2 className="nickname">{nickname}</h2>
         </div>
         <Button
           label="프로필 편집"

--- a/front/src/pages/MyPage.jsx
+++ b/front/src/pages/MyPage.jsx
@@ -19,7 +19,7 @@ const dummyPosts = [
 
 const MyPage = () => {
   const [nickname, setNickname] = useState('');
-  const [profileImage, setProfileImage] = useState(''); // ✅ 프로필 이미지 상태 추가
+  const [profileImage, setProfileImage] = useState(''); // 프로필 이미지 상태 추가
   const [activeTab, setActiveTab] = useState('mypage');
   const [isModalOpen, setIsModalOpen] = useState(false);
 
@@ -34,17 +34,47 @@ const MyPage = () => {
     }
 
     setNickname(storedNickname);
-    if (storedImage) setProfileImage(storedImage); // ✅ 이미지 불러오기
+    if (storedImage) setProfileImage(storedImage); // 이미지 불러오기
   }, []);
 
-  const handleNicknameChange = (newNickname) => {
+  const handleNicknameChange = async (newNickname) => {
+    const email = localStorage.getItem('email');
+
+    // 프론트 상태 반영
     setNickname(newNickname);
     localStorage.setItem('nickname', newNickname);
+
+    // DB에도 저장 시도 (API가 있다고 가정)
+    try {
+      const res = await fetch('http://localhost:8080/api/user/me', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email, nickname: newNickname }),
+      });
+      const result = await res.json();
+      console.log('닉네임 저장됨:', result.message);
+    } catch (err) {
+      console.error('닉네임 저장 실패:', err);
+    }
   };
 
-  const handleImageChange = (newImage) => {
+  const handleImageChange = async (newImage) => {
+    const email = localStorage.getItem('email');
+
     setProfileImage(newImage);
     localStorage.setItem('profileImage', newImage);
+
+    try {
+      const res = await fetch('http://localhost:8080/api/user/me/image', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email, profileImage: newImage }),
+      });
+      const result = await res.json();
+      console.log('이미지 저장됨:', result.message);
+    } catch (err) {
+      console.error('이미지 저장 실패:', err);
+    }
   };
 
   const myPosts = dummyPosts.filter((post) => post.author === nickname);

--- a/front/src/pages/MyPage.jsx
+++ b/front/src/pages/MyPage.jsx
@@ -19,14 +19,14 @@ const dummyPosts = [
 
 const MyPage = () => {
   const [nickname, setNickname] = useState('');
+  const [profileImage, setProfileImage] = useState(''); // ✅ 프로필 이미지 상태 추가
   const [activeTab, setActiveTab] = useState('mypage');
   const [isModalOpen, setIsModalOpen] = useState(false);
 
   useEffect(() => {
-    // 로그인한 사용자만 접근 가능하므로, nickname은 항상 존재한다고 가정
     const storedNickname = localStorage.getItem('nickname');
+    const storedImage = localStorage.getItem('profileImage');
 
-    // 혹시라도 토큰 없이 들어온 경우 방어용
     if (!storedNickname) {
       alert('로그인이 필요합니다.');
       window.location.href = '/login';
@@ -34,7 +34,18 @@ const MyPage = () => {
     }
 
     setNickname(storedNickname);
+    if (storedImage) setProfileImage(storedImage); // ✅ 이미지 불러오기
   }, []);
+
+  const handleNicknameChange = (newNickname) => {
+    setNickname(newNickname);
+    localStorage.setItem('nickname', newNickname);
+  };
+
+  const handleImageChange = (newImage) => {
+    setProfileImage(newImage);
+    localStorage.setItem('profileImage', newImage);
+  };
 
   const myPosts = dummyPosts.filter((post) => post.author === nickname);
 
@@ -44,7 +55,11 @@ const MyPage = () => {
 
       <section className="profile">
         <div className="pic-name">
-          <img src={profileGray} alt="아바타" className="avatar" />
+          <img
+            src={profileImage || profileGray}
+            alt="아바타"
+            className="avatar"
+          />
           <h2 className="nickname">{nickname}</h2>
         </div>
         <Button
@@ -54,7 +69,13 @@ const MyPage = () => {
         />
       </section>
 
-      {isModalOpen && <ProfileModal onClose={() => setIsModalOpen(false)} />}
+      {isModalOpen && (
+        <ProfileModal
+          onClose={() => setIsModalOpen(false)}
+          onNicknameChange={handleNicknameChange}
+          onImageChange={handleImageChange}
+        />
+      )}
 
       <section className="my-posts">
         <h3>작성한 글</h3>
@@ -66,10 +87,10 @@ const MyPage = () => {
           </div>
         ))}
       </section>
+
       <BottomNavBar activeTab={activeTab} setActiveTab={setActiveTab} />
     </div>
   );
 };
-// todo 모달창 더 수정하기
 
 export default MyPage;


### PR DESCRIPTION
## 작업 내용

- 하드코딩된 `"독수리"` → 로그인한 사용자 nickname으로 동적으로 표시
- 저장된 사용자 정보를 기반으로 MyPage, Home 화면 구성
- 로그인하지 않은 경우 `/login`으로 리디렉션 처리
- 닉네임/프로필 이미지 수정 기능 UI 구현 및 상태 반영 로직 작성


## 선반영된 API 프론트 코드
 백엔드는 밑에 1, 2, 3 그리고 참고 사항 보고 백 코드 만들면 될거같아요~

1. 프론트에서 호출하는 API URL
PUT /api/user/me             ← 닉네임 수정
PUT /api/user/me/image       ← 프로필 이미지 수정

2. 요청 형식 (body)
**닉네임 수정**
{
  "email": "test@naver.com",
  "nickname": "독수리짱"
}

**프로필 이미지 수정**
{
  "email": "test@naver.com",
  "profileImage": "data:image/png;base64,..."
}

3. 응답 형식 기대값
{
  "success": true,
  "message": "닉네임 수정 완료" // 또는 "이미지 저장 완료"
}

혹시 요청 형식이나 URL 다르게 하고 싶으시면 말씀해주세요!
프론트 쪽은 수정 금방 가능합니다! 


## 참고 사항

프론트에서 PUT /api/user/me, PUT /api/user/me/image API는
스펙에 맞춰 먼저 구현해둔 상태라, 백엔드에서는 아래 요청 형식 참고해서 컨트롤러/서비스 쪽만 맞추면 될거같아요~

 필요한 DB 필드 (`User` entity 기준)
 `profile_img` (`TEXT` or `VARCHAR`) → base64 문자열 저장을 위한 필드
 
 DB에 `profile_img` 필드가 없다면 `User.java`에 추가 부탁드립니다

## 스크린샷 (선택)

![image](https://github.com/user-attachments/assets/9af6f16d-0d95-41ba-9288-d5cd1818ed14)
현재 제 닉네임은 유니밥입니다.
## 관련 이슈

- Close #40 

<br><br>

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

<br><br>
