### PR TITLE
feat: Mypage에서 프로필이미지 조회 기능 추가

### DIFF
--- a/back/src/main/java/com/univap/controller/UserController.java
+++ b/back/src/main/java/com/univap/controller/UserController.java
@@ -10,6 +10,7 @@ import org.springframework.http.ResponseEntity;
 
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Base64;
@@ -80,6 +81,7 @@ public class UserController {
 
         if(optionalUser.isPresent()){
             User user = optionalUser.get();
+
             try{
                 String image = request.getProfileImage();
                 if(image.contains(",")){
@@ -91,6 +93,17 @@ public class UserController {
                 Path path = Paths.get("uploads/profile/images/" + fileName);
                 Files.createDirectories(path.getParent());
                 Files.write(path, imageBytes);
+
+                if(!user.getImage().isBlank()){
+                    try{
+                        Path oldImagePath = Paths.get(user.getImage());
+                        Files.delete(oldImagePath);
+                    }catch (NoSuchFileException e){
+                        System.out.println("저장된 이미지가 없음" + e.getMessage());
+                    }catch (IOException e){
+                        System.out.println("이미지 삭제 오류" + e.getMessage());
+                    }
+                }
 
                 user.setImage(path.toString());
                 userRepository.save(user);

--- a/back/src/main/java/com/univap/controller/UserController.java
+++ b/back/src/main/java/com/univap/controller/UserController.java
@@ -103,4 +103,26 @@ public class UserController {
             return ResponseEntity.badRequest().body(Map.of("success", false, "message", "사용자 없음"));
         }
     }
+
+    @GetMapping("/me/image/view")
+    public ResponseEntity<?> viewProfileImage(@RequestParam String email) {
+        Optional<User> optionalUser = userRepository.findByEmail(email);
+
+        if(optionalUser.isPresent()){
+            User user = optionalUser.get();
+            if(user.getImage().isBlank()){
+                return ResponseEntity.badRequest().body(Map.of("success", false, "message", "이미지가 설정 되지 않음", "profileImage","기본 이미지"));
+            }
+            Path path = Paths.get(user.getImage());
+
+            try {
+                byte[] bytes = Files.readAllBytes(path);
+                String base64 = "data:image/png;base64," + Base64.getEncoder().encodeToString(bytes);
+                return ResponseEntity.ok(Map.of("success", true, "message", "이미지 로드 성공", "profileImage", base64));
+            } catch (IOException e) {
+                return ResponseEntity.status(500).body(Map.of("success", false, "message", "이미지 로드 실패", "profileImage", "hedgehog"));
+            }
+        }
+        return ResponseEntity.badRequest().body(Map.of("success", false, "message", "존재하지 않는 유저", "profileImage", "nothing"));
+    }
 }

--- a/back/src/main/resources/sql/schema.sql
+++ b/back/src/main/resources/sql/schema.sql
@@ -7,6 +7,6 @@ CREATE TABLE user( #user테이블 생성
     email VARCHAR(100) NOT NULL UNIQUE,
     password VARCHAR(50) NOT NULL,
     univ VARCHAR(50) NOT NULL,
-    profile_img VARCHAR(255),
+    profile_img VARCHAR(255) NOT NULL DEFAULT '',
     nickname VARCHAR(30) NOT NULL
 );

--- a/back/src/main/resources/sql/test.sql
+++ b/back/src/main/resources/sql/test.sql
@@ -20,3 +20,7 @@ SET password = '12345678'
 WHERE id = 4;
 
 commit;
+
+UPDATE user #profile_img가 null일 경우 빈문자열로 바꿔주는 코드
+SET profile_img = ''
+WHERE id = 4;

--- a/back/src/main/resources/sql/update.sql
+++ b/back/src/main/resources/sql/update.sql
@@ -1,0 +1,4 @@
+USE capstone_db;
+
+ALTER TABLE user
+MODIFY profile_img VARCHAR(255) NOT NULL DEFAULT '';

--- a/front/src/pages/MyPage.css
+++ b/front/src/pages/MyPage.css
@@ -14,6 +14,7 @@
   margin-top: 20px;
   width: 70px;
   height: 70px;
+  object-fit: cover;
   border-radius: 50%;
 }
 


### PR DESCRIPTION
## 작업 내용

-Mypage에서 프로필 이미지 조회 기능을 추가했습니다.
-프로필 이미지가 비율에 안맞게 나와서 object-fit:cover를 추가했습니다.
-서버에 저장된 이미지가 변경시 삭제되도록 했습니다.

##API명세
1. URL
GET /api/user/me/image/view <- 프로필 이미지 조회

2. 요청 형식
{
    "email":"test@test.com"
}

3. 응답 형식
{
    "success":true,
    "message":"이미지 로드 완료",
    "profileImage":"data:image/png;base64,..."
}

## 참고 사항

프로필 이미지 조회시에 NPE(NullPointException)의 위험 때문에 db의 일부를 수정하였습니다 (user테이블의 profile_img)
back/src/main/resources/sql 속에 update.sql을 한번 실행시키면 됩니다!
만약 안된다면 기존 정보속에 profile_img가 null이라서 변경할 수 없는 것이니 
test.sql에 있는 null을 빈문자열로 바꿔주는 코드 실행 후에 다시 실행하시면 됩니다

앞으로도 db에 변경이 있는경우 update.sql에 저장해놓도록 하겠습니다
