### PR TITLE
Fix: 닉네임 변경 후에도 이전 작성 게시물의 닉네임이 변경되지 않는 것을 수정하였습니다.

### DIFF
--- a/back/src/main/java/com/univap/controller/PostController.java
+++ b/back/src/main/java/com/univap/controller/PostController.java
@@ -47,7 +47,6 @@ public class PostController {
         post.setLocation(request.getLocation());
         post.setContent(request.getContent());
         post.setUser(user);
-        post.setNickname(user.getNickname());
 
         try{
             postRepository.save(post);

--- a/back/src/main/java/com/univap/dto/post/PostListResponse.java
+++ b/back/src/main/java/com/univap/dto/post/PostListResponse.java
@@ -22,7 +22,7 @@ public class PostListResponse {
         PostListResponse dto = new PostListResponse();
         dto.id = post.getId();
         dto.title = post.getTitle();
-        dto.nickname = post.getNickname();
+        dto.nickname = post.getUser().getNickname();
         dto.location = post.getLocation();
         dto.date = post.getDate();
         dto.time = post.getTime();

--- a/back/src/main/java/com/univap/dto/post/PostViewResponse.java
+++ b/back/src/main/java/com/univap/dto/post/PostViewResponse.java
@@ -22,7 +22,7 @@ public class PostViewResponse {
     public PostViewResponse(Post post){
         this.title = post.getTitle();
         this.content = post.getContent();
-        this.nickname = post.getNickname();
+        this.nickname = post.getUser().getNickname();
         this.date = post.getDate();
         this.time = post.getTime();
         this.location = post.getLocation();

--- a/back/src/main/java/com/univap/entity/Post.java
+++ b/back/src/main/java/com/univap/entity/Post.java
@@ -31,8 +31,6 @@ public class Post {
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
-    private String nickname;
-
     @Column(name = "post_time", insertable = false, updatable = false)
     private LocalDateTime postTime;
 }

--- a/back/src/main/resources/sql/test.sql
+++ b/back/src/main/resources/sql/test.sql
@@ -62,4 +62,4 @@ TRUNCATE TABLE chat_room;
 SET FOREIGN_KEY_CHECKS=1;
 
 
-UPDATE user SET password = '$2a$10$....' WHERE id = ...;
+UPDATE user SET password = '$2a$10$ldXz/aT57qHbGdEhHehes.JdxKsM5iRd.kILOarK0twSd7TsJwh.q' WHERE id = 4;

--- a/back/src/main/resources/sql/update.sql
+++ b/back/src/main/resources/sql/update.sql
@@ -39,3 +39,6 @@ ALTER TABLE chat_message
 ALTER TABLE chat_message
     ADD CONSTRAINT FK_chat_message_sender_user
         FOREIGN KEY (sender_id) REFERENCES user(id);
+
+-- 6월 8일
+ALTER TABLE post DROP COLUMN nickname;


### PR DESCRIPTION
## 작업 내용

닉네임 변경 후에도 이전 작성 게시물의 닉네임이 변경되지 않는 것을 수정하였습니다.

<br><br>

## 참고 사항

<br><br>

## 스크린샷 (선택)

<br><br>

## 관련 이슈

- Close #이슈번호

<br><br>

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

<br><br>
